### PR TITLE
remove .pem files in node_modules after install - ref #33

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,21 @@
+var del = require('del');
+var gulp = require('gulp');
 var elixir = require('laravel-elixir');
+
+/*
+ |--------------------------------------------------------------------------
+ | Pre-defined Gulp Tasks
+ |--------------------------------------------------------------------------
+ |
+ | Tasks outside the scope of Elixir can be predefined before setting it up.
+ |
+ */
+
+gulp.task('postinstall', function (cb) {
+    // .pem files cause Chrome to show a bunch of warnings
+    //so we remove them on postinstall
+    del('node_modules/**/*.pem', cb);
+});
 
 /*
  |--------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "test-react": "jest --verbose --coverage",
     "test-js": "mocha --compilers js:mocha-traceur tests/**/*.spec.js",
     "start": "npm install && bower install && gulp",
-    "lint": "jsxhint --jsx-only ."
+    "lint": "jsxhint --jsx-only .",
+    "postinstall": "gulp postinstall"
   },
   "pre-commit": [
     "lint"
@@ -22,6 +23,7 @@
   "devDependencies": {
     "bower": "^1.4.1",
     "chai": "^3.0.0",
+    "del": "^1.2.0",
     "gulp": "^3.8.8",
     "jest-cli": "^0.4.12",
     "jshint": "^2.8.0",


### PR DESCRIPTION
As suggested in https://github.com/wakatime/chrome-wakatime/issues/33#issuecomment-117302159 this adds a gulp task for deleting all the `.pem` files in the `node_modules` directory after `npm install` is run.  This will remove all the Chrome warnings about having `.pem` files in the application directory.