### PR TITLE
Add ability to use wildcard in white/black url lists

### DIFF
--- a/assets/js/helpers/contains.js
+++ b/assets/js/helpers/contains.js
@@ -17,8 +17,10 @@ function contains(url, list) {
         // If by any chance one line in the list is empty, ignore it
         if(cleanLine === '') continue;
 
-        // If url contains the current line return true
-        if (url.indexOf(cleanLine) > -1) {
+        var lineRe = new RegExp(cleanLine.replace('.', '\.').replace('*', '.*'));
+
+        // If url matches the current line return true
+        if (lineRe.test(url)) {
             return true;
         }
     }


### PR DESCRIPTION
Hello! I have try to add wildcard support in url lists.

To add ability to use `http://*.local` for example

But for some reason can't run tests locally: get en error `SyntaxError: Unexpected token import`