### PR TITLE
Update manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ There is a precommit hook that lints the code before commiting the changes.
 ### Load unpacked in Chrome
 
 1. Clone repository to disk
+2. Remove `browser_specific_settings` key from manifest.json (only necessary for firefox)
 2. Go to `Settings` → `Extensions`
 3. Enable `Developer mode`
 4. Click `Load unpacked extension...`

--- a/manifest.json
+++ b/manifest.json
@@ -37,9 +37,10 @@
     "page": "options.html",
     "chrome_style": false
   },
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
-      "id": "addon@wakatime.com"
+      "id": "addon@wakatime.com",
+      "strict_min_version": "48.0"
     }
   }
 }


### PR DESCRIPTION
This update manifest according to the latest docs of firefox: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings

`browser_specific_settings` replaces `applications` as of firefox 48.

Also added a note in the README for Chrome as this key is unsupported in chrome.