### PR TITLE
chore: Chrome Manifest V2 to V3 migration

### DIFF
--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -1,9 +1,5 @@
 {
-  "background": {
-    "persistent": false,
-    "scripts": ["public/js/browser-polyfill.min.js", "background.js"]
-  },
-  "browser_action": {
+  "action": {
     "default_icon": {
       "19": "graphics/wakatime-logo-19.png",
       "38": "graphics/wakatime-logo-38.png"
@@ -11,27 +7,24 @@
     "default_popup": "popup.html",
     "default_title": "WakaTime"
   },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
   "description": "Automatic time tracking for Chrome.",
   "devtools_page": "devtools.html",
   "homepage_url": "https://wakatime.com",
+  "host_permissions": ["https://api.wakatime.com/*", "https://wakatime.com/*"],
   "icons": {
     "16": "graphics/wakatime-logo-16.png",
     "48": "graphics/wakatime-logo-48.png",
     "128": "graphics/wakatime-logo-128.png"
   },
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "WakaTime",
   "options_ui": {
-    "chrome_style": false,
     "page": "options.html"
   },
-  "permissions": [
-    "https://api.wakatime.com/*",
-    "https://wakatime.com/*",
-    "alarms",
-    "tabs",
-    "storage",
-    "idle"
-  ],
-  "version": "2.0.1"
+  "permissions": ["alarms", "tabs", "storage", "idle"],
+  "version": "3.0.0"
 }


### PR DESCRIPTION
### Summary

V2 of chrome manifest is no longer accepted in by the chrome web store, basically making this a mandatory change.

https://developer.chrome.com/docs/extensions/mv2/