### PR TITLE
chore: send project on heartbeat when navigating on github

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,8 +6,8 @@ We are currently migrating from using [gulp](https://gulpjs.com/) -> [webpack](h
 
 ## Pre-requisites
 
-- node v11.15.0
-- npm 6.7.0
+- node v18.13.0
+- npm 8.19.3
 
 It is suggested you use [nvm](https://github.com/nvm-sh/nvm) to manage your node version
 
@@ -22,7 +22,7 @@ In devmode you can open [local remote devtools](http://localhost:8000)
 ## Development instructions
 
 ```
-    nvm use
+    nvm use 18
     npm install
     npm run dev
 ```

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,33 @@ History
 -------
 
 
+3.0.0 (2023-02-09)
+++++++++++++++++++
+
+- chore: send project on heartbeat when navigating on github
+  `#165 <https://github.com/wakatime/chrome-wakatime/pull/165>`_
+- chore: add social media toggle to track or not social sites
+  `#163 <https://github.com/wakatime/chrome-wakatime/pull/163>`_
+- implement service worker events
+  `#162 <https://github.com/wakatime/chrome-wakatime/pull/162>`_
+- chore: Chrome Manifest V2 to V3 migration
+  `#161 <https://github.com/wakatime/chrome-wakatime/pull/161>`_
+- chore: implements send Heartbeat functionality
+  `#160 <https://github.com/wakatime/chrome-wakatime/pull/160>`_
+- chore: move api key input to options view
+  `#159 <https://github.com/wakatime/chrome-wakatime/pull/159>`_
+- chore: update bootstrap to version 5
+  `#158 <https://github.com/wakatime/chrome-wakatime/pull/158>`_
+- chore: implement options component
+  `#157 <https://github.com/wakatime/chrome-wakatime/pull/157>`_
+- chore: enable disable logging
+  `#156 <https://github.com/wakatime/chrome-wakatime/pull/156>`_
+- chore: implement new ts components
+  `#155 <https://github.com/wakatime/chrome-wakatime/pull/155>`_
+- chore: update dependencies
+  `#153 <https://github.com/wakatime/chrome-wakatime/pull/153>`_
+
+
 2.0.1 (2021-01-11)
 ++++++++++++++++++
 

--- a/manifest.json
+++ b/manifest.json
@@ -39,5 +39,5 @@
     "storage",
     "idle"
   ],
-  "version": "2.0.1"
+  "version": "3.0.0"
 }

--- a/src/core/WakaTimeCore.ts
+++ b/src/core/WakaTimeCore.ts
@@ -82,11 +82,14 @@ class WakaTimeCore {
 
         const currentActiveTab = tabs[0];
 
+        // Checks dev websites
+        const project = this.generateProjectFromDevSites(currentActiveTab.url as string);
+
         if (items.loggingStyle == 'blacklist') {
           if (!contains(currentActiveTab.url as string, items.blacklist as string)) {
             await this.sendHeartbeat(
               {
-                project: null,
+                project,
                 url: currentActiveTab.url as string,
               },
               apiKey,
@@ -103,7 +106,10 @@ class WakaTimeCore {
             items.whitelist as string,
           );
           if (heartbeat.url) {
-            await this.sendHeartbeat(heartbeat, apiKey);
+            await this.sendHeartbeat(
+              { ...heartbeat, project: heartbeat.project ?? project },
+              apiKey,
+            );
           } else {
             await changeExtensionState('whitelisted');
             console.log(`${currentActiveTab.url} is not on a whitelist.`);
@@ -212,6 +218,18 @@ class WakaTimeCore {
     });
 
     return items.loggingType;
+  }
+
+  generateProjectFromDevSites(url: string): string | null {
+    if (url.startsWith('https://github.dev')) {
+      const newUrl = url.replace('https://github.dev', '');
+      return newUrl.split('/')[2];
+    }
+    if (url.startsWith('https://github.com')) {
+      const newUrl = url.replace('https://github.com', '');
+      return newUrl.split('/')[2];
+    }
+    return null;
   }
 
   /**

--- a/src/core/WakaTimeCore.ts
+++ b/src/core/WakaTimeCore.ts
@@ -221,13 +221,12 @@ class WakaTimeCore {
   }
 
   generateProjectFromDevSites(url: string): string | null {
-    if (url.startsWith('https://github.dev')) {
-      const newUrl = url.replace('https://github.dev', '');
-      return newUrl.split('/')[2];
-    }
-    if (url.startsWith('https://github.com')) {
-      const newUrl = url.replace('https://github.com', '');
-      return newUrl.split('/')[2];
+    const githubUrls = ['https://github.com', 'https://github.dev'];
+    for (const githubUrl of githubUrls) {
+      if (url.startsWith(githubUrl)) {
+        const newUrl = url.replace(githubUrl, '');
+        return newUrl.split('/')[2];
+      }
     }
     return null;
   }

--- a/src/core/WakaTimeCore.ts
+++ b/src/core/WakaTimeCore.ts
@@ -229,11 +229,11 @@ class WakaTimeCore {
   }
 
   generateProjectFromDevSites(url: string): string | null {
-    const githubUrls = ['https://github.com', 'https://github.dev'];
+    const githubUrls = ['https://github.com/', 'https://github.dev/'];
     for (const githubUrl of githubUrls) {
       if (url.startsWith(githubUrl)) {
         const newUrl = url.replace(githubUrl, '');
-        return newUrl.split('/')[2];
+        return newUrl.split('/')[1] || null;
       }
     }
     return null;


### PR DESCRIPTION
### Pre-PR Checklist

- [x] I have run `npm test` locally and there are no warnings or errors, from lint or test
- [x] I have added screenshots if applicable

### Summary

Detects github online editor and github website. Sends `project` (repo name) on heartbeat payload when user is navigating on github.com or github.dev


![image](https://user-images.githubusercontent.com/1050904/217360570-950d7c0d-2093-4a39-919f-78fada2adf1c.png)
![image](https://user-images.githubusercontent.com/1050904/217360813-1d6c0b2e-a4f9-457d-aa06-464067fefc19.png)
