### PR TITLE
chore: change webpack devtool option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "chrome-wakatime",
   "private": true,
   "scripts": {
+    "build": "clap build",
     "dev": "clap dev",
     "postinstall": "clap postinstall",
     "lint": "clap lint",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -19,7 +19,7 @@ const browserPolyfill = join(
 );
 const getConfigByBrowser = (isProd: boolean, browser: BrowserTypes): webpack.Configuration => {
   const cfg: webpack.Configuration = {
-    devtool: 'inline-source-map',
+    devtool: 'source-map',
     entry: {
       background: [join(srcFolder, 'background.ts')],
       devtools: [join(srcFolder, 'devtools.ts')],


### PR DESCRIPTION

### Summary
Use a production ready source map for `devtool` option in webpack config https://webpack.js.org/configuration/devtool/

This is improves the file size after building process, 
    1. Improves time to hot reload while developing
    2. FF add on developer hub error for having too larges files goes away
