### PR TITLE
fix: on send heartbeat omit credentials, only use the api key store

### DIFF
--- a/src/core/WakaTimeCore.ts
+++ b/src/core/WakaTimeCore.ts
@@ -337,6 +337,7 @@ class WakaTimeCore {
     try {
       const response = await fetch(`${config.heartbeatApiUrl}?api_key=${apiKey}`, {
         body: JSON.stringify(payload),
+        credentials: 'omit',
         method: 'POST',
       });
       await response.json();

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -26,5 +26,5 @@
     "page": "options.html"
   },
   "permissions": ["alarms", "tabs", "storage", "idle"],
-  "version": "3.0.5"
+  "version": "3.0.6"
 }

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -39,5 +39,5 @@
     "storage",
     "idle"
   ],
-  "version": "3.0.5"
+  "version": "3.0.6"
 }


### PR DESCRIPTION
<!-- Rembember to format your Pull Request Title in the following manner: -->
<!-- Short Description -->

### Pre-PR Checklist

- [x] I have run `npm test` locally and there are no warnings or errors, from lint or test
- [x] I have added screenshots if applicable

### Summary

Fixes tracking heartbeat when a user is logged in into Wakatime website, it uses only the api key to send heartbeats 