### PR TITLE
chore: add hostname option to extension

### DIFF
--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -11,6 +11,7 @@ interface State {
   apiKey: string;
   blacklist: string;
   displayAlert: boolean;
+  hostname: string;
   loading: boolean;
   loggingStyle: string;
   loggingType: string;
@@ -26,6 +27,7 @@ export default function Options(): JSX.Element {
     apiKey: '',
     blacklist: '',
     displayAlert: false,
+    hostname: '',
     loading: false,
     loggingStyle: config.loggingStyle,
     loggingType: config.loggingType,
@@ -41,6 +43,7 @@ export default function Options(): JSX.Element {
     const items = await browser.storage.sync.get({
       apiKey: config.apiKey,
       blacklist: '',
+      hostname: config.hostname,
       loggingStyle: config.loggingStyle,
       loggingType: config.loggingType,
       socialMediaSites: config.socialMediaSites,
@@ -52,6 +55,7 @@ export default function Options(): JSX.Element {
       ...state,
       apiKey: items.apiKey as string,
       blacklist: items.blacklist as string,
+      hostname: items.hostname as string,
       loggingStyle: items.loggingStyle as string,
       loggingType: items.loggingType as string,
       socialMediaSites: items.socialMediaSites as string,
@@ -79,6 +83,7 @@ export default function Options(): JSX.Element {
 
     const apiKey = state.apiKey;
     const theme = state.theme;
+    const hostname = state.hostname;
     const loggingType = state.loggingType;
     const loggingStyle = state.loggingStyle;
     const trackSocialMedia = state.trackSocialMedia;
@@ -91,6 +96,7 @@ export default function Options(): JSX.Element {
     await browser.storage.sync.set({
       apiKey,
       blacklist,
+      hostname,
       loggingStyle,
       loggingType,
       socialMediaSites,
@@ -105,6 +111,7 @@ export default function Options(): JSX.Element {
       apiKey,
       blacklist,
       displayAlert: true,
+      hostname,
       loggingStyle,
       loggingType,
       socialMediaSites,
@@ -245,6 +252,24 @@ export default function Options(): JSX.Element {
                   <option value="light">Light</option>
                   <option value="dark">Dark</option>
                 </select>
+              </div>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="theme" className="col-lg-2 control-label">
+                Hostname
+              </label>
+
+              <div className="col-lg-10">
+                <input
+                  type="text"
+                  className="form-control"
+                  value={state.hostname}
+                  onChange={(e) => setState({ ...state, hostname: e.target.value })}
+                />
+                <span className="help-block">
+                  Optional name of local machine. By default &apos;Unknown Hostname&apos;.
+                </span>
               </div>
             </div>
 

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -44,6 +44,7 @@ describe('wakatime config', () => {
       https://www.udemy.com/
       https://www.w3schools.com/",
         "heartbeatApiUrl": "https://wakatime.com/api/v1/users/current/heartbeats",
+        "hostname": "",
         "loggingEnabled": true,
         "loggingStyle": "blacklist",
         "loggingType": "domain",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -70,6 +70,8 @@ export interface Config {
    * Url to which to send the heartbeat
    */
   heartbeatApiUrl: string;
+
+  hostname: string;
   /**
    * Is logging enabled
    */
@@ -133,6 +135,8 @@ const config: Config = {
 
   heartbeatApiUrl:
     process.env.HEART_BEAT_API_URL ?? 'https://wakatime.com/api/v1/users/current/heartbeats',
+
+  hostname: '',
 
   loggingEnabled: true,
 

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -26,5 +26,5 @@
     "page": "options.html"
   },
   "permissions": ["alarms", "tabs", "storage", "idle"],
-  "version": "3.0.6"
+  "version": "3.0.7"
 }

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -39,5 +39,5 @@
     "storage",
     "idle"
   ],
-  "version": "3.0.6"
+  "version": "3.0.7"
 }

--- a/src/types/heartbeats.ts
+++ b/src/types/heartbeats.ts
@@ -28,6 +28,7 @@ export interface Datum {
 }
 
 export interface SendHeartbeat {
+  hostname: string;
   project: string | null;
   url: string;
 }


### PR DESCRIPTION
<!-- Rembember to format your Pull Request Title in the following manner: -->
<!-- Short Description -->

### Pre-PR Checklist

- [x] I have run `npm test` locally and there are no warnings or errors, from lint or test
- [x] I have added screenshots if applicable

### Summary
https://github.com/wakatime/chrome-wakatime/issues/87

Adds the possibility to users to set up `hostname` on the options of the extension/addon and avoid seeing `Unknown hostname` in reports

![Screen Shot 2023-03-14 at 8 52 47 PM](https://user-images.githubusercontent.com/1050904/225184922-bc1d1c9f-87c3-467a-8ea8-e03b66b013a4.png)
