### PR TITLE
Request host permissions for custom API servers on Firefox

### DIFF
--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -38,6 +38,7 @@
     "chrome_style": false,
     "page": "options.html"
   },
-  "permissions": ["alarms", "tabs", "storage", "activeTab"],
+  "permissions": ["alarms", "tabs", "storage", "activeTab", "https://api.wakatime.com/*", "https://wakatime.com/*"],
+  "optional_permissions": ["<all_urls>"],
   "version": "4.0.9"
 }

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -81,5 +81,10 @@ export const getSettings = async (): Promise<Settings> => {
 };
 
 export const saveSettings = async (settings: Settings): Promise<void> => {
-  return browser.storage.sync.set(settings);
+  // permissions.request must be the first await, not after the browser.storage.sync.set
+  // See https://stackoverflow.com/a/47729896/12601364
+  await browser.permissions.request({
+    origins: [`${settings.apiUrl}/*`],
+  });
+  await browser.storage.sync.set(settings);
 };


### PR DESCRIPTION
`content_scripts.matches` implies permissions to send cross-origin requests on Chrome, but not on Firefox with Manifest V2. We need to request permissions for custom API servers.

ref: #282 #291 #292