### PR TITLE
Separate hostname in settings from sync storage into local storage

### DIFF
--- a/src/core/WakaTimeCore.ts
+++ b/src/core/WakaTimeCore.ts
@@ -165,11 +165,21 @@ class WakaTimeCore {
   }
 
   async sendHeartbeats(): Promise<void> {
-    const settings = await browser.storage.sync.get({
-      apiKey: config.apiKey,
-      heartbeatApiEndPoint: config.heartbeatApiEndPoint,
-      hostname: '',
-    });
+    const [syncSettings, localSettings] = await Promise.all([
+      browser.storage.sync.get({
+        apiKey: config.apiKey,
+        heartbeatApiEndPoint: config.heartbeatApiEndPoint,
+      }) as Promise<{ apiKey: string; heartbeatApiEndPoint: string }>,
+      browser.storage.local.get({
+        hostname: '',
+      }) as Promise<{ hostname: string }>,
+    ]);
+  
+    const settings = {
+      ...syncSettings,
+      hostname: localSettings.hostname,
+    };
+
     if (!settings.apiKey) {
       await changeExtensionStatus('notSignedIn');
       return;


### PR DESCRIPTION
This PR fixes #243 by moving the hostname setting to storage.local to ensure it remains machine-specific and does not sync across browsers.

Changes:
- Updated getSettings and saveSettings to handle hostname in storage.local.
- Refactored sendHeartbeats to fetch hostname from storage.local.