### PR TITLE
Implemented tab groups feature

### DIFF
--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -37,8 +37,8 @@ export default function Options(): JSX.Element {
     loggingStyle: config.loggingStyle,
     loggingType: config.loggingType,
     socialMediaSites: config.socialMediaSites,
-    tabNameFilterList: [],
-    tabNameFilterMode: 'deny',
+    tabGroupNameFilterList: [],
+    tabGroupNameFilterMode: 'deny',
     theme: config.theme,
     trackSocialMedia: config.trackSocialMedia,
     useGroupNameAsProjectName: config.useGroupNameAsProjectName,
@@ -79,8 +79,8 @@ export default function Options(): JSX.Element {
       loggingStyle: state.loggingStyle,
       loggingType: state.loggingType,
       socialMediaSites: state.socialMediaSites.filter((item) => !!item.trim()),
-      tabNameFilterList: state.tabNameFilterList.filter((item) => !!item.trim()),
-      tabNameFilterMode: state.tabNameFilterMode,
+      tabGroupNameFilterList: state.tabGroupNameFilterList.filter((item) => !!item.trim()),
+      tabGroupNameFilterMode: state.tabGroupNameFilterMode,
       theme: state.theme,
       trackSocialMedia: state.trackSocialMedia,
       useGroupNameAsProjectName: state.useGroupNameAsProjectName,
@@ -166,17 +166,17 @@ export default function Options(): JSX.Element {
     }));
   }, []);
 
-  const updateTabNameFilterMode = useCallback((style: string) => {
+  const updateTabGroupNameFilterMode = useCallback((style: string) => {
     setState((oldState) => ({
       ...oldState,
-      tabNameFilterMode: style === 'allow' ? 'allow' : 'deny',
+      tabGroupNameFilterMode: style === 'allow' ? 'allow' : 'deny',
     }));
   }, []);
 
-  const updateTabNameFilterList = useCallback((tabNameFilterList: string[]) => {
+  const updateTabGroupNameFilterList = useCallback((tabGroupNameFilterList: string[]) => {
     setState((oldState) => ({
       ...oldState,
-      tabNameFilterList,
+      tabGroupNameFilterList,
     }));
   }, []);
 
@@ -352,10 +352,10 @@ export default function Options(): JSX.Element {
                     <input
                       id="tabNameFilterDeny"
                       type="radio"
-                      name="tabNameFilterMode"
+                      name="tabGroupNameFilterMode"
                       className="form-check-input"
-                      checked={state.tabNameFilterMode === 'deny'}
-                      onChange={(_) => updateTabNameFilterMode('deny')}
+                      checked={state.tabGroupNameFilterMode === 'deny'}
+                      onChange={(_) => updateTabGroupNameFilterMode('deny')}
                     />
                     <label className="form-check-label" htmlFor="tabNameFilterDeny">
                       Log all tabs except tabs from the list
@@ -366,10 +366,10 @@ export default function Options(): JSX.Element {
                     <input
                       id="tabNameFilterAllow"
                       type="radio"
-                      name="tabNameFilterMode"
+                      name="tabGroupNameFilterMode"
                       className="form-check-input"
-                      checked={state.tabNameFilterMode === 'allow'}
-                      onChange={(_) => updateTabNameFilterMode('allow')}
+                      checked={state.tabGroupNameFilterMode === 'allow'}
+                      onChange={(_) => updateTabGroupNameFilterMode('allow')}
                     />
                     <label className="form-check-label" htmlFor="tabNameFilterAllow">
                       Log only tabs from the list
@@ -377,15 +377,15 @@ export default function Options(): JSX.Element {
                   </div>
 
                   <SitesList
-                    addButtonLabel="Add tab/workspace name"
-                    handleChange={updateTabNameFilterList}
-                    urlPlaceholder="ExactTabName or *wildcard*"
-                    label="Tab names"
-                    sites={state.tabNameFilterList}
+                    addButtonLabel="Add tab group/workspace name"
+                    handleChange={updateTabGroupNameFilterList}
+                    urlPlaceholder="ExactTabGroupName or *wildcard*"
+                    label="Tab group names"
+                    sites={state.tabGroupNameFilterList}
                     helpText={
-                      state.tabNameFilterMode === 'deny'
-                        ? 'Tab names that you want to exclude from logging. Supports wildcards (*): chat* matches "chatroom" or "chat group", *debug* matches any name containing "debug".'
-                        : 'Tab names that you want to log. Supports wildcards (*): chat* matches "chatroom" or "chat group", *debug* matches any name containing "debug".'
+                      state.tabGroupNameFilterMode === 'deny'
+                        ? 'Tab group names that you want to exclude from logging. Supports wildcards (*): chat* matches "chatroom" or "chat group", *debug* matches any name containing "debug".'
+                        : 'Tab group names that you want to log. Supports wildcards (*): chat* matches "chatroom" or "chat group", *debug* matches any name containing "debug".'
                     }
                   />
                 </div>

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -358,7 +358,7 @@ export default function Options(): JSX.Element {
                       onChange={(_) => updateTabGroupNameFilterMode('deny')}
                     />
                     <label className="form-check-label" htmlFor="tabNameFilterDeny">
-                      Log all tabs except tabs from the list
+                      Log all except tabs from the tab group list
                     </label>
                   </div>
 
@@ -372,7 +372,7 @@ export default function Options(): JSX.Element {
                       onChange={(_) => updateTabGroupNameFilterMode('allow')}
                     />
                     <label className="form-check-label" htmlFor="tabNameFilterAllow">
-                      Log only tabs from the list
+                      Log only from the tab group list
                     </label>
                   </div>
 

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -379,6 +379,7 @@ export default function Options(): JSX.Element {
                   <SitesList
                     addButtonLabel="Add tab/workspace name"
                     handleChange={updateTabNameFilterList}
+                    urlPlaceholder="ExactTabName or *wildcard*"
                     label="Tab names"
                     sites={state.tabNameFilterList}
                     helpText={

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -37,6 +37,8 @@ export default function Options(): JSX.Element {
     loggingStyle: config.loggingStyle,
     loggingType: config.loggingType,
     socialMediaSites: config.socialMediaSites,
+    tabNameFilterList: [],
+    tabNameFilterMode: 'deny',
     theme: config.theme,
     trackSocialMedia: config.trackSocialMedia,
     useGroupNameAsProjectName: config.useGroupNameAsProjectName,
@@ -77,6 +79,8 @@ export default function Options(): JSX.Element {
       loggingStyle: state.loggingStyle,
       loggingType: state.loggingType,
       socialMediaSites: state.socialMediaSites.filter((item) => !!item.trim()),
+      tabNameFilterList: state.tabNameFilterList.filter((item) => !!item.trim()),
+      tabNameFilterMode: state.tabNameFilterMode,
       theme: state.theme,
       trackSocialMedia: state.trackSocialMedia,
       useGroupNameAsProjectName: state.useGroupNameAsProjectName,
@@ -159,6 +163,20 @@ export default function Options(): JSX.Element {
     setState((oldState) => ({
       ...oldState,
       logOnlyGroupedTabsActivity: !oldState.logOnlyGroupedTabsActivity,
+    }));
+  }, []);
+
+  const updateTabNameFilterMode = useCallback((style: string) => {
+    setState((oldState) => ({
+      ...oldState,
+      tabNameFilterMode: style === 'allow' ? 'allow' : 'deny',
+    }));
+  }, []);
+
+  const updateTabNameFilterList = useCallback((tabNameFilterList: string[]) => {
+    setState((oldState) => ({
+      ...oldState,
+      tabNameFilterList,
     }));
   }, []);
 
@@ -316,7 +334,6 @@ export default function Options(): JSX.Element {
 
               <div>
                 <input
-                  disabled={IS_OPERA}
                   type="checkbox"
                   className="me-2"
                   checked={state.logOnlyGroupedTabsActivity}
@@ -326,6 +343,52 @@ export default function Options(): JSX.Element {
                   Log only grouped tabs activity
                 </span>
               </div>
+
+              {(state.useGroupNameAsProjectName || state.logOnlyGroupedTabsActivity) && (
+                <div className="mt-3 ps-3">
+                  <label className="form-label">Tab name filter</label>
+
+                  <div className="form-check mb-3">
+                    <input
+                      id="tabNameFilterDeny"
+                      type="radio"
+                      name="tabNameFilterMode"
+                      className="form-check-input"
+                      checked={state.tabNameFilterMode === 'deny'}
+                      onChange={(_) => updateTabNameFilterMode('deny')}
+                    />
+                    <label className="form-check-label" htmlFor="tabNameFilterDeny">
+                      Log all tabs except tabs from the list
+                    </label>
+                  </div>
+
+                  <div className="form-check mb-3">
+                    <input
+                      id="tabNameFilterAllow"
+                      type="radio"
+                      name="tabNameFilterMode"
+                      className="form-check-input"
+                      checked={state.tabNameFilterMode === 'allow'}
+                      onChange={(_) => updateTabNameFilterMode('allow')}
+                    />
+                    <label className="form-check-label" htmlFor="tabNameFilterAllow">
+                      Log only tabs from the list
+                    </label>
+                  </div>
+
+                  <SitesList
+                    addButtonLabel="Add tab/workspace name"
+                    handleChange={updateTabNameFilterList}
+                    label="Tab names"
+                    sites={state.tabNameFilterList}
+                    helpText={
+                      state.tabNameFilterMode === 'deny'
+                        ? 'Tab names that you want to exclude from logging. Supports wildcards (*): chat* matches "chatroom" or "chat group", *debug* matches any name containing "debug".'
+                        : 'Tab names that you want to log. Supports wildcards (*): chat* matches "chatroom" or "chat group", *debug* matches any name containing "debug".'
+                    }
+                  />
+                </div>
+              )}
 
               {IS_YANDEX && (
                 <details>
@@ -350,7 +413,7 @@ export default function Options(): JSX.Element {
                     'Also be aware that in Opera every tab is in a workspace(either the default one, or created by you). '
                   }
                   {
-                    'That\'s why the "Log only grouped tabs activity" checkbox is disabled in Opera. It will have no effect'
+                    'That\'s why you may want to set up the "Tab name filter" feature to filter all the unwanted workspaces(for example the default one) from your activity'
                   }
                 </span>
               )}

--- a/src/components/SitesList.tsx
+++ b/src/components/SitesList.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 
 type Props = {
+  addButtonLabel?: string;
   handleChange: (sites: string[]) => void;
   helpText: string;
   label: string;
@@ -10,6 +11,7 @@ type Props = {
 };
 
 export default function SitesList({
+  addButtonLabel = 'Add Site',
   handleChange,
   label,
   urlPlaceholder,
@@ -66,7 +68,7 @@ export default function SitesList({
 
       <button type="button" onClick={handleAddNewSite} className="btn btn-default col-12">
         <i className="fa fa-fw fa-plus me-2" />
-        Add Site
+        {addButtonLabel}
       </button>
       <span className="text-secondary">{helpText}</span>
     </div>

--- a/src/components/YaBrowserSpaceNameMatchList.tsx
+++ b/src/components/YaBrowserSpaceNameMatchList.tsx
@@ -1,0 +1,145 @@
+import React, { useCallback, useRef } from 'react';
+import { YaBrowserSpaceNameMatch } from '../utils/settings';
+
+type Props = {
+  onChange: (value: YaBrowserSpaceNameMatch) => void;
+  value: YaBrowserSpaceNameMatch;
+};
+
+export default function YaBrowserSpaceNameMatchList({ value, onChange }: Props): JSX.Element {
+  const tabsCountGrouped = useRef<Record<string, number | undefined>>({});
+
+  const handleAdd = useCallback(async () => {
+    tabsCountGrouped.current = (await chrome.tabs.query({})).reduce<Record<string, number>>(
+      (p, c) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        const spaceId = (c as any).spaceId as string;
+        p[spaceId] = (p[spaceId] ?? 0) + 1;
+        return p;
+      },
+      {},
+    );
+    const existingMatches = new Set(Object.keys(value));
+    let foundSpaceId: string | undefined;
+    for (const e of Object.entries(tabsCountGrouped.current)) {
+      if (!existingMatches.has(e[0])) {
+        foundSpaceId = e[0];
+        break;
+      }
+    }
+
+    if (foundSpaceId == undefined) return;
+    const updated = {
+      ...value,
+      [foundSpaceId]: '',
+    };
+
+    onChange(updated);
+  }, [onChange, value]);
+
+  const handleRemove = useCallback(
+    (spaceId: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete value[spaceId];
+      onChange(value);
+    },
+    [onChange, value],
+  );
+
+  const handleGroupNameChange = useCallback(
+    (spaceId: string, val: string) => {
+      value[spaceId] = val.trim();
+
+      onChange(value);
+    },
+    [onChange, value],
+  );
+
+  return (
+    <div className="form-group mb-4 d-flex flex-column gap-3">
+      <span style={{ fontSize: '12px' }} className="text-secondary">
+        <div>
+          By default in Yandex Browser groups(spaces) feature is disabled, because there is no way
+          programmatically to distinct grouped tabs from ungrouped. All of them are grouped. Also
+          there is no API for getting the group(space) name. This is why this form exists. If you
+          want to use the groups features(use group name as project name and/or log only grouped
+          tabs) you need to do some extra steps: you need to mannualy match the group(space) id to a
+          readable name(that will be used as Project name).
+        </div>
+        <div>Here is how it works:</div>
+        <div>{'1. Press the "Search for spaces(tab groups)" button.'}</div>
+        <div>
+          2. You will see a space(group) id, provided by Yandex Browser API. Also you will see a
+          caption saying how many tabs are in the group with this space id. This is how you can make
+          an assumption about which group this id belongs to.
+        </div>
+        <div>
+          {'3. Now, when you know what space(group) the space id you are seeing belongs to, '}
+          {'you can give a name to this space(create a match). '}
+          {
+            'Also do not forget to toggle the "Use tab\'s group name as project name" checkbox for this feature to work'
+          }
+        </div>
+        <div>{'4. Press "Save"'}</div>
+        <div>
+          Now you are all set! The activity will be logged using the provided space(group) name as
+          Project name!
+        </div>
+      </span>
+      <label style={{ fontSize: '14px' }} className="control-label">
+        {'Yandex Browser spaceId to name match'}
+      </label>
+      {Object.keys(value).length > 0 ? (
+        <div className="d-flex flex-column gap-2">
+          {Object.entries(value).map((row, i) => (
+            <div key={i} className="d-flex gap-2 align-items-center">
+              <div className="flex-fill">
+                <label style={{ fontSize: '12px' }} className="form-label" htmlFor={`spaceId-${i}`}>
+                  {tabsCountGrouped.current[row[0]] == undefined
+                    ? ''
+                    : `${tabsCountGrouped.current[row[0]]} tabs in the space with id:`}
+                </label>
+                <input
+                  id={`spaceId-${i}`}
+                  disabled={true}
+                  placeholder={'spaceId'}
+                  className="form-control"
+                  value={row[0]}
+                />
+              </div>
+              <div className="flex-fill">
+                <label
+                  style={{ fontSize: '12px' }}
+                  className="form-label"
+                  htmlFor={`groupName-${i}`}
+                >
+                  {tabsCountGrouped.current[row[0]] == undefined || (row[1] ?? '') !== ''
+                    ? ''
+                    : `Enter a name for the tab containing ${tabsCountGrouped.current[row[0]]} tabs`}
+                </label>
+                <input
+                  id={`groupName-${i}`}
+                  placeholder={'Group Name'}
+                  className="form-control"
+                  value={row[1] ?? ''}
+                  onChange={(e) => handleGroupNameChange(row[0], e.target.value)}
+                />
+              </div>
+
+              <button
+                type="button"
+                className="btn btn-sm btn-default ms-2"
+                onClick={() => handleRemove(row[0])}
+              >
+                <i className="fa fa-fw fa-times" />
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      <button type="button" onClick={handleAdd} className="btn btn-default col-12 flex-fill">
+        Search for spaces(tab groups)
+      </button>
+    </div>
+  );
+}

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -49,6 +49,7 @@ describe('wakatime config', () => {
         ],
         "heartbeatApiEndPoint": "/users/current/heartbeats.bulk",
         "hostname": "",
+        "logOnlyGroupedTabsActivity": false,
         "loggingEnabled": true,
         "loggingStyle": "deny",
         "loggingType": "domain",
@@ -87,6 +88,7 @@ describe('wakatime config', () => {
           "trackingDisabled": "Not logging",
         },
         "trackSocialMedia": true,
+        "useGroupNameAsProjectName": false,
         "version": "test-version",
       }
     `);

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -80,6 +80,8 @@ describe('wakatime config', () => {
           "ignored",
         ],
         "summariesApiEndPoint": "/users/current/summaries",
+        "tabNameFilterList": [],
+        "tabNameFilterMode": "deny",
         "theme": "light",
         "tooltips": {
           "allGood": "",

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -80,8 +80,8 @@ describe('wakatime config', () => {
           "ignored",
         ],
         "summariesApiEndPoint": "/users/current/summaries",
-        "tabNameFilterList": [],
-        "tabNameFilterMode": "deny",
+        "tabGroupNameFilterList": [],
+        "tabGroupNameFilterMode": "deny",
         "theme": "light",
         "tooltips": {
           "allGood": "",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -75,6 +75,10 @@ export interface Config {
   hostname: string;
 
   /**
+   * Whether to log activity only for grouped tabs
+   */
+  logOnlyGroupedTabsActivity: boolean;
+  /**
    * Is logging enabled
    */
   loggingEnabled: boolean;
@@ -101,7 +105,13 @@ export interface Config {
    */
   theme: Theme;
   tooltips: Tooltips;
+
   trackSocialMedia: boolean;
+  /**
+   * Whether to use the tab group's name as project name
+   * (if the tab is in a group)
+   */
+  useGroupNameAsProjectName: boolean;
   /**
    * Version of the extension
    */
@@ -152,6 +162,8 @@ const config: Config = {
 
   hostname: '',
 
+  logOnlyGroupedTabsActivity: false,
+
   loggingEnabled: true,
 
   loggingStyle: 'deny',
@@ -185,14 +197,15 @@ const config: Config = {
   summariesApiEndPoint: process.env.SUMMARIES_API_URL ?? '/users/current/summaries',
 
   theme: 'light',
-
   tooltips: {
     allGood: '',
     ignored: 'This URL is ignored',
     notSignedIn: 'Not signed In',
     trackingDisabled: 'Not logging',
   },
+
   trackSocialMedia: true,
+  useGroupNameAsProjectName: false,
 
   version: browser.runtime.getManifest().version,
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,9 +10,9 @@ export type ExtensionStatus = 'allGood' | 'trackingDisabled' | 'notSignedIn' | '
 export type LoggingStyle = 'allow' | 'deny';
 
 /**
- * Tab name filter mode: 'deny' to exclude tabs, 'allow' to include only specified tabs
+ * Tab group name filter mode: 'deny' to exclude tab groups, 'allow' to include only specified tab groups
  */
-export type TabNameFilterMode = 'allow' | 'deny';
+export type TabGroupNameFilterMode = 'allow' | 'deny';
 
 /**
  * Logging type
@@ -108,11 +108,11 @@ export interface Config {
   /**
    * List of tab names to filter
    */
-  tabNameFilterList: string[];
+  tabGroupNameFilterList: string[];
   /**
-   * Tab name filter mode: 'deny' to exclude tabs, 'allow' to include only specified tabs
+   * Tab group name filter mode: 'deny' to exclude tab groups, 'allow' to include only specified tab groups
    */
-  tabNameFilterMode: TabNameFilterMode;
+  tabGroupNameFilterMode: TabGroupNameFilterMode;
   /**
    * Options for theme
    */
@@ -209,9 +209,9 @@ const config: Config = {
 
   summariesApiEndPoint: process.env.SUMMARIES_API_URL ?? '/users/current/summaries',
 
-  tabNameFilterList: [],
+  tabGroupNameFilterList: [],
 
-  tabNameFilterMode: 'deny',
+  tabGroupNameFilterMode: 'deny',
 
   theme: 'light',
   tooltips: {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,6 +10,11 @@ export type ExtensionStatus = 'allGood' | 'trackingDisabled' | 'notSignedIn' | '
 export type LoggingStyle = 'allow' | 'deny';
 
 /**
+ * Tab name filter mode: 'deny' to exclude tabs, 'allow' to include only specified tabs
+ */
+export type TabNameFilterMode = 'allow' | 'deny';
+
+/**
  * Logging type
  */
 export type LoggingType = 'domain' | 'url';
@@ -100,6 +105,14 @@ export interface Config {
    * Get stats from the wakatime api
    */
   summariesApiEndPoint: string;
+  /**
+   * List of tab names to filter
+   */
+  tabNameFilterList: string[];
+  /**
+   * Tab name filter mode: 'deny' to exclude tabs, 'allow' to include only specified tabs
+   */
+  tabNameFilterMode: TabNameFilterMode;
   /**
    * Options for theme
    */
@@ -195,6 +208,10 @@ const config: Config = {
   states: ['allGood', 'trackingDisabled', 'notSignedIn', 'ignored'],
 
   summariesApiEndPoint: process.env.SUMMARIES_API_URL ?? '/users/current/summaries',
+
+  tabNameFilterList: [],
+
+  tabNameFilterMode: 'deny',
 
   theme: 'light',
   tooltips: {

--- a/src/core/WakaTimeCore.ts
+++ b/src/core/WakaTimeCore.ts
@@ -97,18 +97,18 @@ class WakaTimeCore {
   shouldLogTabByName(tabName: string | undefined, settings: Settings): boolean {
     if (!settings.useGroupNameAsProjectName && !settings.logOnlyGroupedTabsActivity) return true;
     if (!tabName) return true;
-    if (settings.tabNameFilterList.length === 0) return true;
+    if (settings.tabGroupNameFilterList.length === 0) return true;
 
-    if (settings.tabNameFilterMode === 'deny') {
+    if (settings.tabGroupNameFilterMode === 'deny') {
       return (
-        settings.tabNameFilterList.find((pattern) => {
+        settings.tabGroupNameFilterList.find((pattern) => {
           const re = new RegExp(pattern.replace(/\*/g, '.*'));
           return re.test(tabName);
         }) == undefined
       );
     } else {
       return (
-        settings.tabNameFilterList.find((pattern) => {
+        settings.tabGroupNameFilterList.find((pattern) => {
           const re = new RegExp(pattern.replace(/\*/g, '.*'));
           return re.test(tabName);
         }) !== undefined

--- a/src/core/WakaTimeCore.ts
+++ b/src/core/WakaTimeCore.ts
@@ -94,6 +94,28 @@ class WakaTimeCore {
     return site?.projectName;
   }
 
+  shouldLogTabByName(tabName: string | undefined, settings: Settings): boolean {
+    if (!settings.useGroupNameAsProjectName && !settings.logOnlyGroupedTabsActivity) return true;
+    if (!tabName) return true;
+    if (settings.tabNameFilterList.length === 0) return true;
+
+    if (settings.tabNameFilterMode === 'deny') {
+      return (
+        settings.tabNameFilterList.find((pattern) => {
+          const re = new RegExp(pattern.replace(/\*/g, '.*'));
+          return re.test(tabName);
+        }) == undefined
+      );
+    } else {
+      return (
+        settings.tabNameFilterList.find((pattern) => {
+          const re = new RegExp(pattern.replace(/\*/g, '.*'));
+          return re.test(tabName);
+        }) !== undefined
+      );
+    }
+  }
+
   async handleActivity(tabId: number, isPassiveActivity: boolean = false) {
     const settings = await getSettings();
     if (!settings.loggingEnabled) {
@@ -221,6 +243,10 @@ class WakaTimeCore {
 
       if (settings.useGroupNameAsProjectName) groupName = _groupName;
       if (settings.logOnlyGroupedTabsActivity && _groupName === undefined) return;
+    }
+
+    if (!this.shouldLogTabByName(groupName, settings)) {
+      return;
     }
 
     return {

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -32,6 +32,6 @@
   "options_ui": {
     "page": "options.html"
   },
-  "permissions": ["alarms", "tabs", "storage", "activeTab"],
+  "permissions": ["alarms", "tabs", "storage", "activeTab", "tabGroups"],
   "version": "4.1.0"
 }

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -34,11 +34,19 @@
   },
   "manifest_version": 2,
   "name": "WakaTime",
+  "optional_permissions": ["<all_urls>"],
   "options_ui": {
     "chrome_style": false,
     "page": "options.html"
   },
-  "permissions": ["alarms", "tabs", "storage", "activeTab", "https://api.wakatime.com/*", "https://wakatime.com/*"],
-  "optional_permissions": ["<all_urls>"],
+  "permissions": [
+    "alarms",
+    "tabs",
+    "storage",
+    "activeTab",
+    "tabGroups",
+    "https://api.wakatime.com/*",
+    "https://wakatime.com/*"
+  ],
   "version": "4.1.0"
 }

--- a/src/utils/operatingSystem.ts
+++ b/src/utils/operatingSystem.ts
@@ -1,5 +1,7 @@
 export const IS_EDGE = navigator.userAgent.includes('Edg');
 export const IS_FIREFOX = navigator.userAgent.includes('Firefox');
+export const IS_YANDEX = navigator.userAgent.includes('YaBrowser');
+export const IS_OPERA = navigator.userAgent.includes('OPR');
 export const IS_CHROME = !IS_EDGE && !IS_FIREFOX;
 
 export const getOperatingSystem = (): Promise<string> => {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -6,6 +6,8 @@ export interface ProjectName {
   url: string;
 }
 
+export type YaBrowserSpaceNameMatch = Record<string, string | undefined>;
+
 export interface Settings {
   allowList: string[];
   apiKey: string;
@@ -14,12 +16,15 @@ export interface Settings {
   denyList: string[];
   extensionStatus: ExtensionStatus;
   hostname: string;
+  logOnlyGroupedTabsActivity: boolean;
   loggingEnabled: boolean;
   loggingStyle: LoggingStyle;
   loggingType: LoggingType;
   socialMediaSites: string[];
   theme: Theme;
   trackSocialMedia: boolean;
+  useGroupNameAsProjectName: boolean;
+  yaBrowserSpaceNameMatch: YaBrowserSpaceNameMatch;
 }
 
 export const getSettings = async (): Promise<Settings> => {
@@ -31,13 +36,16 @@ export const getSettings = async (): Promise<Settings> => {
     customProjectNames: [],
     denyList: [],
     hostname: config.hostname,
+    logOnlyGroupedTabsActivity: false,
     loggingEnabled: config.loggingEnabled,
     loggingStyle: config.loggingStyle,
     loggingType: config.loggingType,
     socialMediaSites: config.socialMediaSites,
     theme: config.theme,
     trackSocialMedia: true,
+    useGroupNameAsProjectName: false,
     whitelist: null,
+    yaBrowserSpaceNameMatch: {},
   })) as Omit<Settings, 'socialMediaSites'> & {
     blacklist?: string;
     socialMediaSites: string[] | string;
@@ -71,12 +79,15 @@ export const getSettings = async (): Promise<Settings> => {
     denyList: settings.denyList,
     extensionStatus: settings.extensionStatus,
     hostname: settings.hostname,
+    logOnlyGroupedTabsActivity: settings.logOnlyGroupedTabsActivity,
     loggingEnabled: settings.loggingEnabled,
     loggingStyle: settings.loggingStyle,
     loggingType: settings.loggingType,
     socialMediaSites: settings.socialMediaSites,
     theme: settings.theme,
     trackSocialMedia: settings.trackSocialMedia,
+    useGroupNameAsProjectName: settings.useGroupNameAsProjectName,
+    yaBrowserSpaceNameMatch: settings.yaBrowserSpaceNameMatch,
   };
 };
 

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,5 +1,11 @@
 import browser from 'webextension-polyfill';
-import config, { ExtensionStatus, LoggingStyle, LoggingType, Theme } from '../config/config';
+import config, {
+  ExtensionStatus,
+  LoggingStyle,
+  LoggingType,
+  TabNameFilterMode,
+  Theme,
+} from '../config/config';
 
 export interface ProjectName {
   projectName: string;
@@ -21,6 +27,8 @@ export interface Settings {
   loggingStyle: LoggingStyle;
   loggingType: LoggingType;
   socialMediaSites: string[];
+  tabNameFilterList: string[];
+  tabNameFilterMode: TabNameFilterMode;
   theme: Theme;
   trackSocialMedia: boolean;
   useGroupNameAsProjectName: boolean;
@@ -41,6 +49,8 @@ export const getSettings = async (): Promise<Settings> => {
     loggingStyle: config.loggingStyle,
     loggingType: config.loggingType,
     socialMediaSites: config.socialMediaSites,
+    tabNameFilterList: [],
+    tabNameFilterMode: 'deny',
     theme: config.theme,
     trackSocialMedia: true,
     useGroupNameAsProjectName: false,
@@ -84,6 +94,8 @@ export const getSettings = async (): Promise<Settings> => {
     loggingStyle: settings.loggingStyle,
     loggingType: settings.loggingType,
     socialMediaSites: settings.socialMediaSites,
+    tabNameFilterList: settings.tabNameFilterList,
+    tabNameFilterMode: settings.tabNameFilterMode,
     theme: settings.theme,
     trackSocialMedia: settings.trackSocialMedia,
     useGroupNameAsProjectName: settings.useGroupNameAsProjectName,

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -3,7 +3,7 @@ import config, {
   ExtensionStatus,
   LoggingStyle,
   LoggingType,
-  TabNameFilterMode,
+  TabGroupNameFilterMode,
   Theme,
 } from '../config/config';
 
@@ -27,8 +27,8 @@ export interface Settings {
   loggingStyle: LoggingStyle;
   loggingType: LoggingType;
   socialMediaSites: string[];
-  tabNameFilterList: string[];
-  tabNameFilterMode: TabNameFilterMode;
+  tabGroupNameFilterList: string[];
+  tabGroupNameFilterMode: TabGroupNameFilterMode;
   theme: Theme;
   trackSocialMedia: boolean;
   useGroupNameAsProjectName: boolean;
@@ -49,8 +49,8 @@ export const getSettings = async (): Promise<Settings> => {
     loggingStyle: config.loggingStyle,
     loggingType: config.loggingType,
     socialMediaSites: config.socialMediaSites,
-    tabNameFilterList: [],
-    tabNameFilterMode: 'deny',
+    tabGroupNameFilterList: [],
+    tabGroupNameFilterMode: 'deny',
     theme: config.theme,
     trackSocialMedia: true,
     useGroupNameAsProjectName: false,
@@ -94,8 +94,8 @@ export const getSettings = async (): Promise<Settings> => {
     loggingStyle: settings.loggingStyle,
     loggingType: settings.loggingType,
     socialMediaSites: settings.socialMediaSites,
-    tabNameFilterList: settings.tabNameFilterList,
-    tabNameFilterMode: settings.tabNameFilterMode,
+    tabGroupNameFilterList: settings.tabGroupNameFilterList,
+    tabGroupNameFilterMode: settings.tabGroupNameFilterMode,
     theme: settings.theme,
     trackSocialMedia: settings.trackSocialMedia,
     useGroupNameAsProjectName: settings.useGroupNameAsProjectName,


### PR DESCRIPTION
Browsers have tab groups(spaces, workspaces, islands).

I thought that it will be very convenient to group my tabs by projects in those tab groups, and say to the wakatime extension to use the tab group name as a project name, instead of using the "Custom project name" feature(not very convenient) or logging the `<<LAST PROJECT>>`(not very accurate).

So this is what was done in this PR.

"Tab groups" settings were added to Options page:
<img width="392" height="518" alt="image" src="https://github.com/user-attachments/assets/3126076a-9046-440e-9ee3-e28d773867f5" />

Now you can enable the "Use tab's group name as project name" checkbox(disabled by default to keep the backwards compatibility), and the tab group name, if the tab is in a group, of course, will be used as a project name. For example, if the group name is "My Company Name", then you'll see on the Wakatime dashboard all the activity from the tabs within this tab group logged under the name "My Company Name".

Also you have the checkbox "Log only grouped tabs activity"(off by default, to keep the backwards compatibility). With this option all the activity from ungrouped tabs will be ignored. For example, if you want to have some tabs for your personal use, and don't want Wakatime to log them, you can have them ungrouped, and enable this checkbox. In this case, the Wakatime extension will log only activity from grouped tabs(for example from "My Company Name" group), and the activity from ungrouped tabs(your personal use) will be ignored.

And then, if any of the above mentioned checkboxes is checked, you also have the option to filter the heartbeats by the tab group/workspace name they're sent from. For example, you may have a tab group/workspace named "My company name", and you want the heartbeats to be sent only from this tab group. So you choose the "Log only from the tab group list" option, enter "My company name", and hit "Save". Now only the activity from "My company name" tab group/workspace will be logged. Or you can have a lot of projects, grouped by workspaces, and one workspace for your personal purposes. In this case you choose the option "Log all except tabs from the tab group list", and add to the list one item with your personal tab group/workspace name, hit "Save". This way you'll have in your wakatime dashboard your projects grouped by name(tab group/workspace name), and, at the same time, your personal activity won't be logged.

Worth to mention:
Features were tested on Google Chrome, Firefox, Opera, Yandex Browser.

**In Chrome and Firefox everything works out-of the box, as described above.**

**If you're using Opera**, be aware that Opera has two types of groups:
1. [Workspaces](https://www.opera.com/features/workspaces)
2. [Tab islands](https://www.opera.com/features/tab-islands)

You need to use the workspaces, not tab islands, because tab islands are anonimous(don't have names).

**If you're using Yandex browser**
You'll have to go through some extra setup, as Yandex Browser doesn't support the default chrome's tab groups feature.
Instead it has something like Opera's workspaces. In Yandex Browser they called it "space". Also, unlike Opera, their API don't provide the space name. So you'll have to manually match the space id to a name. You'll be provided with instructions when you'll open the Options page.