### PR TITLE
Improve API key setup guidance

### DIFF
--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -33,7 +33,8 @@ export default function Options(): JSX.Element {
     trackSocialMedia: config.trackSocialMedia,
   });
 
-  const isApiKeyValid = useMemo(() => apiKeyInvalid(state.apiKey) === '', [state.apiKey]);
+  const apiKeyValidationMessage = useMemo(() => apiKeyInvalid(state.apiKey), [state.apiKey]);
+  const shouldShowApiKeyError = state.apiKey.trim().length > 0 && apiKeyValidationMessage !== '';
 
   const loggingStyleRef = useRef(null);
 
@@ -168,11 +169,24 @@ export default function Options(): JSX.Element {
                 id="apiKey"
                 autoFocus={true}
                 type="text"
-                className={`form-control ${isApiKeyValid ? '' : 'is-invalid'}`}
-                placeholder="API key"
+                className={`form-control ${shouldShowApiKeyError ? 'is-invalid' : ''}`}
+                placeholder="waka_xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
                 value={state.apiKey}
+                aria-describedby="apiKeyHelp apiKeyFeedback"
                 onChange={(e) => setState({ ...state, apiKey: e.target.value })}
               />
+              <div id="apiKeyHelp" className="form-text">
+                Paste your WakaTime API key from{' '}
+                <a href="https://wakatime.com/settings/api-key" target="_blank" rel="noreferrer">
+                  Account Settings
+                </a>
+                .
+              </div>
+              {shouldShowApiKeyError ? (
+                <div id="apiKeyFeedback" className="invalid-feedback">
+                  {apiKeyValidationMessage}
+                </div>
+              ) : null}
             </div>
 
             <div className="form-group mb-4">

--- a/src/utils/apiKey.test.ts
+++ b/src/utils/apiKey.test.ts
@@ -1,0 +1,16 @@
+import apiKeyInvalid from './apiKey';
+
+describe('apiKeyInvalid', () => {
+  it('points users directly to the API key settings page', () => {
+    expect(apiKeyInvalid('not-a-key')).toBe(
+      'Invalid API key. Copy your key from https://wakatime.com/settings/api-key',
+    );
+  });
+
+  it('accepts WakaTime API keys with or without waka_ prefix', () => {
+    const uuidKey = '12345678-1234-4123-8123-123456789abc';
+
+    expect(apiKeyInvalid(uuidKey)).toBe('');
+    expect(apiKeyInvalid(`waka_${uuidKey}`)).toBe('');
+  });
+});

--- a/src/utils/apiKey.ts
+++ b/src/utils/apiKey.ts
@@ -1,5 +1,5 @@
 export default function apiKeyInvalid(key?: string): string {
-  const err = 'Invalid api key... check https://wakatime.com/settings for your key';
+  const err = 'Invalid API key. Copy your key from https://wakatime.com/settings/api-key';
   if (!key) return err;
   const re = new RegExp(
     '^(waka_)?[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$',


### PR DESCRIPTION
## Summary
- don't mark the API key field invalid before a user has typed anything
- add a direct link to the WakaTime API key settings page
- clarify the API key placeholder and validation message
- add unit coverage for the API key validation copy and accepted key formats

## Why
From a new-user point of view, the options page previously opened with an empty API key field already styled as invalid and only a generic placeholder. This makes setup feel broken before the user has done anything. The direct account-settings link and less aggressive validation make first-run setup clearer.

## Validation
- `npx jest src/utils/apiKey.test.ts --runInBand`
- `npx eslint src/components/Options.tsx src/utils/apiKey.ts src/utils/apiKey.test.ts`
- `npm run build`

Note: `npx tsc --noEmit` still fails on existing project type issues in @types/glob/minimatch and src/stores/createStore.ts; I did not change those files.